### PR TITLE
Voeg niveau-parameter toe voor student- of inschrijvingsniveau

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ Output/
 
 # Omgeving
 .env
+/doc/
+/Meta/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Authors@R: c(
   )
 Description: Calculates enrolment, graduation, dropout, and programme-switch
     indicators from the Dutch higher education registration data (1CHO)
-    supplied by DUO. Includes an interactive Shiny dashboard for exploring
+    supplied by DUO. Includes an interactive 'Shiny' dashboard for exploring
     results.
 License: MIT + file LICENSE
 URL: https://github.com/cedanl/staat-van-onderwijsinstelling

--- a/R/combineer.R
+++ b/R/combineer.R
@@ -1,18 +1,26 @@
+utils::globalVariables("uitval_3jr")
+
 #' Combineer alle indicatoren tot een analysebestand
 #'
-#' Voegt rendement-, uitval- en studiewisselindicatoren samen met het
-#' instroomcohort. Past kolomnamen en factorniveaus aan voor gebruik in
+#' Voegt rendement-, uitval- en (optioneel) studiewisselindicatoren samen met
+#' het instroomcohort. Past kolomnamen en factorniveaus aan voor gebruik in
 #' rapportages.
 #'
 #' @param cohorten_instroom Tibble zoals gemaakt door [maak_instroom_cohort()]
 #' @param rendement_indicatoren Tibble zoals gemaakt door [bereken_rendement()]
 #' @param uitval_indicatoren Tibble zoals gemaakt door [bereken_uitval()]
 #' @param studiewissel_indicatoren Tibble zoals gemaakt door
-#'   [bereken_studiewissel()]
+#'   [bereken_studiewissel()], of `NULL`. Studiewissel is een
+#'   studentniveau-concept en alleen van toepassing bij
+#'   `niveau = "student"`. Geef `NULL` door bij inschrijvingsniveau.
+#' @param niveau Analyseniveau: `"student"` (standaard) of `"inschrijving"`.
+#'   Moet overeenkomen met het niveau waarop de andere invoertibbles zijn
+#'   aangemaakt.
 #'
-#' @return Een tibble met een rij per student en gecombineerde indicator-
-#'   kolommen, klaar voor rapportage. Bevat o.a. `status`, `rendement`,
-#'   `uitval`, `studiewissel` en alle onderliggende deelscores.
+#' @return Een tibble met gecombineerde indicatorkolommen, klaar voor
+#'   rapportage. Bevat o.a. `status`, `rendement`, `uitval` en alle
+#'   onderliggende deelscores. Bij `niveau = "student"` zijn ook
+#'   studiewisselkolommen aanwezig als `studiewissel_indicatoren` is meegegeven.
 #'
 #' @examples
 #' cohort <- tibble::tibble(
@@ -71,16 +79,24 @@ combineer_indicatoren <- function(
   cohorten_instroom,
   rendement_indicatoren,
   uitval_indicatoren,
-  studiewissel_indicatoren
+  studiewissel_indicatoren = NULL,
+  niveau = "student"
 ) {
-  cohorten_instroom |>
-    dplyr::left_join(rendement_indicatoren, by = "persoonsgebonden_nummer") |>
-    dplyr::left_join(uitval_indicatoren, by = "persoonsgebonden_nummer") |>
-    dplyr::left_join(
+  sleutels <- niveau_sleutels(niveau)
+
+  result <- cohorten_instroom |>
+    dplyr::left_join(rendement_indicatoren, by = sleutels) |>
+    dplyr::left_join(uitval_indicatoren, by = sleutels)
+
+  if (!is.null(studiewissel_indicatoren)) {
+    result <- dplyr::left_join(
+      result,
       studiewissel_indicatoren,
       by = "persoonsgebonden_nummer"
-    ) |>
+    )
+  }
 
+  result <- result |>
     dplyr::select(
       inschrijvingsjaar,
       geslacht = geslacht_label,
@@ -97,7 +113,19 @@ combineer_indicatoren <- function(
       status,
       soortdiploma = soort_diploma_instelling_label,
       rendement_3jr:rendement_8jr,
-      uitval_xjr:sector_na_switch3jr
+      uitval_xjr:uitval_3jr,
+      dplyr::any_of(c(
+        "studiewissel_1jr",
+        "studiewissel_3jr",
+        "opleidingscode_na_switch1jr",
+        "opleidingsvorm_na_switch1jr",
+        "opleidingsniveau_na_switch1jr",
+        "sector_na_switch1jr",
+        "opleidingscode_na_switch3jr",
+        "opleidingsvorm_na_switch3jr",
+        "opleidingsniveau_na_switch3jr",
+        "sector_na_switch3jr"
+      ))
     ) |>
 
     dplyr::mutate(
@@ -150,13 +178,6 @@ combineer_indicatoren <- function(
         uitval_xjr > 3 ~ "Uitgevallen na 3 jaar",
         TRUE ~ "Niet uitgevallen"
       ),
-      studiewissel = dplyr::case_when(
-        studiewissel_1jr ==
-          "Gewisseld binnen 1 jaar" ~ "Gewisseld binnen 1 jaar",
-        studiewissel_3jr ==
-          "Gewisseld binnen 3 jaar" ~ "Gewisseld in het 2e of 3e jaar",
-        TRUE ~ "Niet gewisseld"
-      ),
       rendement = dplyr::case_when(
         rendement_5jr == "Diploma binnen 5 jaar" ~ "Diploma binnen 5 jaar",
         rendement_8jr == "Diploma binnen 8 jaar" ~ "Diploma binnen 5-8 jaar",
@@ -165,4 +186,19 @@ combineer_indicatoren <- function(
         rendement_8jr == "Onbekend (diplomajaar voor instroomjaar)" ~ "Onbekend"
       )
     )
+
+  if (!is.null(studiewissel_indicatoren)) {
+    result <- result |>
+      dplyr::mutate(
+        studiewissel = dplyr::case_when(
+          studiewissel_1jr ==
+            "Gewisseld binnen 1 jaar" ~ "Gewisseld binnen 1 jaar",
+          studiewissel_3jr ==
+            "Gewisseld binnen 3 jaar" ~ "Gewisseld in het 2e of 3e jaar",
+          TRUE ~ "Niet gewisseld"
+        )
+      )
+  }
+
+  result
 }

--- a/R/dashboard.R
+++ b/R/dashboard.R
@@ -3,8 +3,9 @@
 #' Opent de interactieve Shiny app waarmee je een 1CHO CSV-bestand kunt
 #' uploaden en studie-indicatoren kunt verkennen.
 #'
+#' @return No return value, called for side effects.
 #' @examples
-#' \dontrun{
+#' if (interactive()) {
 #'   start_dashboard()
 #' }
 #' @export

--- a/R/instroom.R
+++ b/R/instroom.R
@@ -1,14 +1,19 @@
 #' Lees het 1CHO-bestand in en voeg label-kolommen toe
 #'
+#' Leest een semicolongescheiden CSV-bestand (UTF-8) in en voegt
+#' extra `_label`-kolommen toe voor gebruik in rapportages. Het pakket
+#' bevat een klein synthetisch voorbeeldbestand zonder echte persoonsgegevens
+#' (`inst/extdata/voorbeeld_1cho.csv`).
+#'
 #' @param pad_invoer Pad naar het semicolongescheiden CSV-bestand (UTF-8)
 #'
 #' @return Een tibble met alle 1CHO-regels plus extra `_label`-kolommen die de
 #'   originele categorische waarden bewaren voor gebruik in rapportages
 #'
 #' @examples
-#' \dontrun{
-#'   basis <- maak_basisbestand("pad/naar/1cho_enriched.csv")
-#' }
+#' # voorbeeld_1cho.csv is a small synthetic dataset bundled with the package
+#' pad <- system.file("extdata/voorbeeld_1cho.csv", package = "staat1cho")
+#' basis <- suppressMessages(maak_basisbestand(pad))
 #' @export
 maak_basisbestand <- function(pad_invoer) {
   invoer <- readr::read_csv2(
@@ -47,10 +52,15 @@ maak_basisbestand <- function(pad_invoer) {
 #' @param basisbestand Tibble zoals gemaakt door [maak_basisbestand()]
 #' @param soort_ho Character vector met toegestane waarden van
 #'   `soort_hoger_onderwijs`, bijv. `c("hoger beroepsonderwijs", "hbo")`
+#' @param niveau Analyseniveau: `"student"` (standaard) of `"inschrijving"`.
+#'   Bij `"student"` is de sleutel `persoonsgebonden_nummer`; bij
+#'   `"inschrijving"` is de sleutel de combinatie
+#'   `persoonsgebonden_nummer` + `opleiding_actueel_equivalent`.
 #'
-#' @return Een tibble met één rij per student, aangevuld met kolom
-#'   `eerstejaar_instelling` (= inschrijvingsjaar). Gooit een fout als er
-#'   dubbele persoonsgebonden nummers zijn.
+#' @return Een tibble met een rij per student (bij `niveau = "student"`) of per
+#'   student-opleidingcombinatie (bij `niveau = "inschrijving"`), aangevuld met
+#'   kolom `eerstejaar_instelling` (= inschrijvingsjaar). Gooit een fout als er
+#'   dubbele sleutelcombinaties zijn.
 #'
 #' @examples
 #' basis <- tibble::tibble(
@@ -64,7 +74,7 @@ maak_basisbestand <- function(pad_invoer) {
 #' )
 #' maak_instroom_cohort(basis, "hbo")
 #' @export
-maak_instroom_cohort <- function(basisbestand, soort_ho) {
+maak_instroom_cohort <- function(basisbestand, soort_ho, niveau = "student") {
   cohort <- basisbestand |>
     dplyr::filter(soort_hoger_onderwijs %in% soort_ho) |>
     dplyr::filter(
@@ -74,9 +84,10 @@ maak_instroom_cohort <- function(basisbestand, soort_ho) {
     ) |>
     dplyr::mutate(eerstejaar_instelling = inschrijvingsjaar)
 
-  if (any(duplicated(cohort$persoonsgebonden_nummer))) {
+  sleutels <- niveau_sleutels(niveau)
+  if (anyDuplicated(cohort[sleutels]) > 0) {
     rlang::abort(
-      "Dubbele studentnummers in het instroomcohortbestand gevonden!"
+      "Dubbele sleutelcombinaties in het instroomcohortbestand gevonden!"
     )
   }
 

--- a/R/rendement.R
+++ b/R/rendement.R
@@ -1,14 +1,16 @@
-#' Maak een bestand met het vroegst behaalde diploma per student
+#' Maak een bestand met het vroegst behaalde diploma per student (of inschrijving)
 #'
 #' Filtert het basisbestand op diplomasoorten die gelden als afgeronde opleiding
-#' en behoudt per student alleen het eerste diploma op basis van diplomajaar.
+#' en behoudt per sleutel alleen het eerste diploma op basis van diplomajaar.
 #'
 #' @param basisbestand Tibble zoals gemaakt door [maak_basisbestand()]
+#' @param niveau Analyseniveau: `"student"` (standaard) of `"inschrijving"`.
+#'   Bepaalt de sleutel waarop gededupliceerd wordt.
 #'
-#' @return Een tibble met één rij per student met kolommen
-#'   `persoonsgebonden_nummer`, `jaar_eerste_diploma`,
-#'   `verblijfsjaar_eerste_diploma` en `diploma`. Gooit een fout bij
-#'   dubbele persoonsgebonden nummers.
+#' @return Een tibble met één rij per student (bij `niveau = "student"`) of per
+#'   student-opleidingcombinatie (bij `niveau = "inschrijving"`), met kolommen
+#'   voor de sleutel(s), `jaar_eerste_diploma`, `verblijfsjaar_eerste_diploma`
+#'   en `diploma`. Gooit een fout bij dubbele sleutelcombinaties.
 #'
 #' @examples
 #' basis <- tibble::tibble(
@@ -22,7 +24,7 @@
 #' )
 #' maak_diploma_behaald(basis)
 #' @export
-maak_diploma_behaald <- function(basisbestand) {
+maak_diploma_behaald <- function(basisbestand, niveau = "student") {
   diplomas <- c(
     "Hoofd-bachelor-diploma binnen de actuele instelling",
     "Neven-bachelor-diploma binnen de actuele instelling",
@@ -38,13 +40,15 @@ maak_diploma_behaald <- function(basisbestand) {
     "Nevendiploma postinitiele master binnen de actuele instelling"
   )
 
+  sleutels <- niveau_sleutels(niveau)
+
   diploma_behaald <- basisbestand |>
     dplyr::filter(soort_diploma_instelling %in% diplomas) |>
     ## diplomajaar == 0 betekent geen jaar geregistreerd in de 1CHO-data
     dplyr::mutate(diplomajaar = dplyr::na_if(diplomajaar, 0)) |>
-    dplyr::group_by(persoonsgebonden_nummer) |>
+    dplyr::group_by(dplyr::across(dplyr::all_of(sleutels))) |>
     dplyr::arrange(diplomajaar, .by_group = TRUE) |>
-    dplyr::distinct(persoonsgebonden_nummer, .keep_all = TRUE) |>
+    dplyr::distinct(dplyr::across(dplyr::all_of(sleutels)), .keep_all = TRUE) |>
     dplyr::ungroup() |>
     dplyr::mutate(
       jaar_eerste_diploma = diplomajaar,
@@ -52,14 +56,14 @@ maak_diploma_behaald <- function(basisbestand) {
       diploma = "Diploma behaald (excl. propedeuse)"
     ) |>
     dplyr::select(
-      persoonsgebonden_nummer,
+      dplyr::all_of(sleutels),
       jaar_eerste_diploma,
       verblijfsjaar_eerste_diploma,
       diploma
     )
 
-  if (any(duplicated(diploma_behaald$persoonsgebonden_nummer))) {
-    rlang::abort("Dubbele studentnummers in het diplomabestand gevonden!")
+  if (anyDuplicated(diploma_behaald[sleutels]) > 0) {
+    rlang::abort("Dubbele sleutelcombinaties in het diplomabestand gevonden!")
   }
 
   diploma_behaald
@@ -72,11 +76,14 @@ maak_diploma_behaald <- function(basisbestand) {
 #'
 #' @param cohorten_instroom Tibble zoals gemaakt door [maak_instroom_cohort()]
 #' @param diploma_behaald Tibble zoals gemaakt door [maak_diploma_behaald()]
+#' @param niveau Analyseniveau: `"student"` (standaard) of `"inschrijving"`.
+#'   Moet overeenkomen met het niveau waarop `cohorten_instroom` en
+#'   `diploma_behaald` zijn aangemaakt.
 #'
-#' @return Een tibble met kolommen `persoonsgebonden_nummer`,
-#'   `eerstejaar_instelling`, `jaar_eerste_diploma`,
-#'   `verblijfsjaar_eerste_diploma`, `diploma`, `rendement_xjaar`,
-#'   en factorkolommen `rendement_3jr`, `rendement_5jr`, `rendement_8jr`
+#' @return Een tibble met kolommen voor de sleutel(s), `eerstejaar_instelling`,
+#'   `jaar_eerste_diploma`, `verblijfsjaar_eerste_diploma`, `diploma`,
+#'   `rendement_xjaar`, en factorkolommen `rendement_3jr`, `rendement_5jr`,
+#'   `rendement_8jr`
 #'
 #' @examples
 #' cohort <- tibble::tibble(
@@ -91,11 +98,17 @@ maak_diploma_behaald <- function(basisbestand) {
 #' )
 #' bereken_rendement(cohort, diploma)
 #' @export
-bereken_rendement <- function(cohorten_instroom, diploma_behaald) {
+bereken_rendement <- function(
+  cohorten_instroom,
+  diploma_behaald,
+  niveau = "student"
+) {
+  sleutels <- niveau_sleutels(niveau)
+
   cohorten_instroom |>
-    dplyr::left_join(diploma_behaald, by = "persoonsgebonden_nummer") |>
+    dplyr::left_join(diploma_behaald, by = sleutels) |>
     dplyr::select(
-      persoonsgebonden_nummer,
+      dplyr::all_of(sleutels),
       eerstejaar_instelling,
       jaar_eerste_diploma,
       verblijfsjaar_eerste_diploma,

--- a/R/uitval.R
+++ b/R/uitval.R
@@ -1,20 +1,23 @@
 #' Bereken uitvalindicatoren per cohort
 #'
-#' Bepaalt voor elke student in het instroomcohort of zij zijn uitgevallen,
-#' zittend of gediplomeerd. Uitval wordt gemarkeerd als een student niet meer
-#' ingeschreven staat en geen diploma heeft.
+#' Bepaalt voor elke student (of inschrijving) in het instroomcohort of zij zijn
+#' uitgevallen, zittend of gediplomeerd. Uitval wordt gemarkeerd als een student
+#' niet meer ingeschreven staat en geen diploma heeft.
 #'
 #' @param basisbestand Tibble zoals gemaakt door [maak_basisbestand()]
 #' @param diploma_behaald Tibble zoals gemaakt door [maak_diploma_behaald()]
 #' @param cohorten_instroom Tibble zoals gemaakt door [maak_instroom_cohort()]
 #' @param jaar Integer, peiljaar van de analyse (bijv. `2025`). Studenten die
 #'   in `jaar - 1` nog ingeschreven staan, gelden als zittend.
+#' @param niveau Analyseniveau: `"student"` (standaard) of `"inschrijving"`.
+#'   Moet overeenkomen met het niveau waarop de andere invoertibbles zijn
+#'   aangemaakt.
 #'
-#' @return Een tibble met kolommen `persoonsgebonden_nummer`,
-#'   `laatste_jaar_inschrijving`, `diploma`, `status` (factor:
-#'   Diploma behaald / Zittend / Uitgevallen), `uitval_xjr` (jaar van uitval
-#'   t.o.v. instroomjaar), `uitval_1jr` en `uitval_3jr` (factoren).
-#'   Gooit een fout bij dubbele studenten of ontbrekende statussen.
+#' @return Een tibble met de sleutelkolom(men), `laatste_jaar_inschrijving`,
+#'   `diploma`, `status` (factor: Diploma behaald / Zittend / Uitgevallen),
+#'   `uitval_xjr` (jaar van uitval t.o.v. instroomjaar), `uitval_1jr` en
+#'   `uitval_3jr` (factoren). Gooit een fout bij dubbele sleutelcombinaties of
+#'   ontbrekende statussen.
 #'
 #' @examples
 #' basis <- tibble::tibble(
@@ -38,17 +41,20 @@ bereken_uitval <- function(
   basisbestand,
   diploma_behaald,
   cohorten_instroom,
-  jaar
+  jaar,
+  niveau = "student"
 ) {
-  ## Bepaal het laatste inschrijvingsjaar per student
+  sleutels <- niveau_sleutels(niveau)
+
+  ## Bepaal het laatste inschrijvingsjaar per sleutelcombinatie
   uitstroom <- basisbestand |>
-    dplyr::group_by(persoonsgebonden_nummer) |>
+    dplyr::group_by(dplyr::across(dplyr::all_of(sleutels))) |>
     dplyr::arrange(
       dplyr::desc(inschrijvingsjaar),
       soort_inschrijving_actuele_instelling,
       .by_group = TRUE
     ) |>
-    dplyr::distinct(persoonsgebonden_nummer, .keep_all = TRUE) |>
+    dplyr::distinct(dplyr::across(dplyr::all_of(sleutels)), .keep_all = TRUE) |>
     dplyr::ungroup() |>
     dplyr::mutate(
       ## jaar - 1 is het meest recente studiejaar in de data; studenten die
@@ -60,21 +66,21 @@ bereken_uitval <- function(
       )
     ) |>
     dplyr::select(
-      persoonsgebonden_nummer,
+      dplyr::all_of(sleutels),
       inschrijvingsjaar,
       laatste_jaar_inschrijving
     )
 
-  if (any(duplicated(uitstroom$persoonsgebonden_nummer))) {
-    rlang::abort("Dubbele studentnummers in het uitvalbestand gevonden!")
+  if (anyDuplicated(uitstroom[sleutels]) > 0) {
+    rlang::abort("Dubbele sleutelcombinaties in het uitvalbestand gevonden!")
   }
 
   uitval <- uitstroom |>
-    dplyr::left_join(diploma_behaald, by = "persoonsgebonden_nummer") |>
+    dplyr::left_join(diploma_behaald, by = sleutels) |>
     dplyr::left_join(
       cohorten_instroom |>
-        dplyr::select(persoonsgebonden_nummer, eerstejaar_instelling),
-      by = "persoonsgebonden_nummer"
+        dplyr::select(dplyr::all_of(sleutels), eerstejaar_instelling),
+      by = sleutels
     ) |>
     dplyr::mutate(
       status = factor(dplyr::case_when(
@@ -97,7 +103,7 @@ bereken_uitval <- function(
       ))
     ) |>
     dplyr::select(
-      persoonsgebonden_nummer,
+      dplyr::all_of(sleutels),
       laatste_jaar_inschrijving,
       diploma,
       status,

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,7 @@
+niveau_sleutels <- function(niveau) {
+  if (niveau == "inschrijving") {
+    c("persoonsgebonden_nummer", "opleiding_actueel_equivalent")
+  } else {
+    "persoonsgebonden_nummer"
+  }
+}

--- a/inst/app/app.R
+++ b/inst/app/app.R
@@ -311,7 +311,11 @@ trend_lijn <- function(
     thema()
 }
 
-instroom_trend <- function(data, titel = "Instroom per cohortjaar") {
+instroom_trend <- function(
+  data,
+  titel = "Instroom per cohortjaar",
+  y_label = "Studenten"
+) {
   if (nrow(data) == 0) {
     return(leeg_plot())
   }
@@ -324,7 +328,7 @@ instroom_trend <- function(data, titel = "Instroom per cohortjaar") {
     geom_line(data = lijn_data, color = NPULS_BLAUW, linewidth = 1.3) +
     geom_point(color = NPULS_BLAUW, size = 3) +
     scale_x_continuous(breaks = scales::pretty_breaks(n = 7)) +
-    labs(x = "Instroomjaar", y = "Studenten", title = titel) +
+    labs(x = "Instroomjaar", y = y_label, title = titel) +
     thema()
 }
 
@@ -607,6 +611,7 @@ ui <- page_fluid(
 server <- function(input, output, session) {
   fase <- reactiveVal("upload")
   df_data <- reactiveVal(NULL)
+  analyse_niveau <- reactiveVal("student")
 
   ## Scherm switch ----
 
@@ -643,6 +648,16 @@ server <- function(input, output, session) {
               buttonLabel = "Bladeren...",
               placeholder = "Geen bestand geselecteerd"
             ),
+            radioButtons(
+              "analyse_niveau",
+              "Analyseniveau",
+              choices = c(
+                "Studentniveau" = "student",
+                "Inschrijvingsniveau" = "inschrijving"
+              ),
+              selected = "student",
+              inline = TRUE
+            ),
             uiOutput("btn_verwerk_ui")
           )
         )
@@ -664,6 +679,10 @@ server <- function(input, output, session) {
             class = "dashboard-brand",
             "Staat van Onderwijsinstelling",
             tags$span("Onderwijs bewegen.", class = "npuls-payoff")
+          ),
+          tags$span(
+            if (analyse_niveau() == "inschrijving") "Inschrijvingsniveau" else "Studentniveau",
+            style = "margin-left:1rem;background:#D6E2FD;color:#3D68EC;font-size:0.7rem;font-weight:600;padding:0.2rem 0.65rem;border-radius:999px;text-transform:uppercase;letter-spacing:0.06em;"
           ),
           tags$div(
             style = "margin-left:auto;",
@@ -866,34 +885,38 @@ server <- function(input, output, session) {
               )
             ),
 
-            ## Studiewissel ----
-            nav_panel(
-              "Studiewissel",
-              layout_columns(
-                col_widths = c(6, 6),
-                uiOutput("kpi_wissel1"),
-                uiOutput("kpi_wissel3")
-              ),
-              card(
-                card_header("Studiewissel per cohortjaar"),
-                plotlyOutput("plot_wissel_trend", height = "420px")
-              ),
-              layout_columns(
-                col_widths = c(4, 4, 4),
-                card(
-                  card_header("Studiewissel samengevat"),
-                  plotlyOutput("plot_wissel_samen", height = "260px")
+            ## Studiewissel (alleen bij studentniveau) ----
+            if (analyse_niveau() == "student") {
+              nav_panel(
+                "Studiewissel",
+                layout_columns(
+                  col_widths = c(6, 6),
+                  uiOutput("kpi_wissel1"),
+                  uiOutput("kpi_wissel3")
                 ),
                 card(
-                  card_header("Sector na wissel (1 jaar)"),
-                  plotlyOutput("plot_wissel_sector1", height = "260px")
+                  card_header("Studiewissel per cohortjaar"),
+                  plotlyOutput("plot_wissel_trend", height = "420px")
                 ),
-                card(
-                  card_header("Sector na wissel (3 jaar)"),
-                  plotlyOutput("plot_wissel_sector3", height = "260px")
+                layout_columns(
+                  col_widths = c(4, 4, 4),
+                  card(
+                    card_header("Studiewissel samengevat"),
+                    plotlyOutput("plot_wissel_samen", height = "260px")
+                  ),
+                  card(
+                    card_header("Sector na wissel (1 jaar)"),
+                    plotlyOutput("plot_wissel_sector1", height = "260px")
+                  ),
+                  card(
+                    card_header("Sector na wissel (3 jaar)"),
+                    plotlyOutput("plot_wissel_sector3", height = "260px")
+                  )
                 )
               )
-            ),
+            } else {
+              NULL
+            },
 
             ## Data ----
             nav_panel(
@@ -967,28 +990,46 @@ server <- function(input, output, session) {
 
           soort_ho <- unique(basisbestand$soort_hoger_onderwijs)
 
+          niv <- input$analyse_niveau
+          analyse_niveau(niv)
+
           setProgress(0.25, detail = "Instroomcohort aanmaken")
-          cohorten <- maak_instroom_cohort(basisbestand, soort_ho)
+          cohorten <- maak_instroom_cohort(basisbestand, soort_ho, niveau = niv)
 
           setProgress(0.40, detail = "Diploma bepalen")
-          diploma <- maak_diploma_behaald(basisbestand)
+          diploma <- maak_diploma_behaald(basisbestand, niveau = niv)
 
           setProgress(0.55, detail = "Rendement berekenen")
-          rendement <- bereken_rendement(cohorten, diploma)
+          rendement <- bereken_rendement(cohorten, diploma, niveau = niv)
 
           setProgress(0.70, detail = "Uitval berekenen")
-          uitval <- bereken_uitval(basisbestand, diploma, cohorten, jaar)
-
-          setProgress(0.85, detail = "Studiewissel berekenen")
-          wissel <- bereken_studiewissel(
+          uitval <- bereken_uitval(
             basisbestand,
-            cohorten,
             diploma,
-            uitval
+            cohorten,
+            jaar,
+            niveau = niv
           )
 
+          wissel <- NULL
+          if (niv == "student") {
+            setProgress(0.85, detail = "Studiewissel berekenen")
+            wissel <- bereken_studiewissel(
+              basisbestand,
+              cohorten,
+              diploma,
+              uitval
+            )
+          }
+
           setProgress(0.95, detail = "Combineren")
-          result <- combineer_indicatoren(cohorten, rendement, uitval, wissel)
+          result <- combineer_indicatoren(
+            cohorten,
+            rendement,
+            uitval,
+            wissel,
+            niveau = niv
+          )
 
           naam_tabel <- dplyr::distinct(
             basisbestand,
@@ -1052,17 +1093,28 @@ server <- function(input, output, session) {
   ## Sidebar teller ----
 
   output$n_label <- renderUI({
-    tags$p(tags$strong(n_label(nrow(df()))), " studenten", class = "n-students")
+    eenheid <- if (analyse_niveau() == "inschrijving") {
+      "inschrijvingen"
+    } else {
+      "studenten"
+    }
+    tags$p(
+      tags$strong(n_label(nrow(df()))),
+      paste0(" ", eenheid),
+      class = "n-students"
+    )
   })
 
   ## KPI's overzicht ----
 
-  output$kpi_n <- renderUI(vb(
-    "Studenten",
-    n_label(nrow(df())),
-    bg = NPULS_BLAUW,
-    fg = NPULS_GEEL
-  ))
+  output$kpi_n <- renderUI({
+    label <- if (analyse_niveau() == "inschrijving") {
+      "Inschrijvingen"
+    } else {
+      "Studenten"
+    }
+    vb(label, n_label(nrow(df())), bg = NPULS_BLAUW, fg = NPULS_GEEL)
+  })
   output$kpi_diploma <- renderUI(vb(
     "Diploma behaald",
     pct_label(df(), \(d) d$status == "Diploma behaald"),
@@ -1075,12 +1127,18 @@ server <- function(input, output, session) {
     bg = NPULS_ORANJE,
     fg = NPULS_ZWART
   ))
-  output$kpi_wissel_ov <- renderUI(vb(
-    "Gewisseld binnen 1 jaar",
-    pct_label(df(), \(d) d$studiewissel_1jr == "Gewisseld binnen 1 jaar"),
-    bg = NPULS_GEEL,
-    fg = NPULS_ZWART
-  ))
+  output$kpi_wissel_ov <- renderUI({
+    if (analyse_niveau() == "inschrijving") {
+      vb("Gewisseld binnen 1 jaar", "—", bg = NPULS_GEEL, fg = NPULS_ZWART)
+    } else {
+      vb(
+        "Gewisseld binnen 1 jaar",
+        pct_label(df(), \(d) d$studiewissel_1jr == "Gewisseld binnen 1 jaar"),
+        bg = NPULS_GEEL,
+        fg = NPULS_ZWART
+      )
+    }
+  })
 
   ## KPI's rendement ----
 
@@ -1145,7 +1203,13 @@ server <- function(input, output, session) {
   output$plot_ov_geslacht <- renderPlotly(ggplotly(pct_bar(df(), geslacht)))
   output$plot_ov_vorm <- renderPlotly(ggplotly(pct_bar(df(), opleidingsvorm)))
   output$plot_overzicht_instroom <- renderPlotly(
-    ggplotly(instroom_trend(df()), tooltip = c("x", "y")) |>
+    ggplotly(
+      instroom_trend(
+        df(),
+        y_label = if (analyse_niveau() == "inschrijving") "Inschrijvingen" else "Studenten"
+      ),
+      tooltip = c("x", "y")
+    ) |>
       layout(
         legend = list(
           x = 0.01,
@@ -1163,7 +1227,13 @@ server <- function(input, output, session) {
   ## Plots instroom ----
 
   output$plot_instroom_trend <- renderPlotly(
-    ggplotly(instroom_trend(df()), tooltip = c("x", "y")) |>
+    ggplotly(
+      instroom_trend(
+        df(),
+        y_label = if (analyse_niveau() == "inschrijving") "Inschrijvingen" else "Studenten"
+      ),
+      tooltip = c("x", "y")
+    ) |>
       layout(
         legend = list(
           x = 0.01,

--- a/man/bereken_rendement.Rd
+++ b/man/bereken_rendement.Rd
@@ -4,18 +4,22 @@
 \alias{bereken_rendement}
 \title{Bereken rendementsindicatoren per cohort}
 \usage{
-bereken_rendement(cohorten_instroom, diploma_behaald)
+bereken_rendement(cohorten_instroom, diploma_behaald, niveau = "student")
 }
 \arguments{
 \item{cohorten_instroom}{Tibble zoals gemaakt door \code{\link[=maak_instroom_cohort]{maak_instroom_cohort()}}}
 
 \item{diploma_behaald}{Tibble zoals gemaakt door \code{\link[=maak_diploma_behaald]{maak_diploma_behaald()}}}
+
+\item{niveau}{Analyseniveau: \code{"student"} (standaard) of \code{"inschrijving"}.
+Moet overeenkomen met het niveau waarop \code{cohorten_instroom} en
+\code{diploma_behaald} zijn aangemaakt.}
 }
 \value{
-Een tibble met kolommen \code{persoonsgebonden_nummer},
-\code{eerstejaar_instelling}, \code{jaar_eerste_diploma},
-\code{verblijfsjaar_eerste_diploma}, \code{diploma}, \code{rendement_xjaar},
-en factorkolommen \code{rendement_3jr}, \code{rendement_5jr}, \code{rendement_8jr}
+Een tibble met kolommen voor de sleutel(s), \code{eerstejaar_instelling},
+\code{jaar_eerste_diploma}, \code{verblijfsjaar_eerste_diploma}, \code{diploma},
+\code{rendement_xjaar}, en factorkolommen \code{rendement_3jr}, \code{rendement_5jr},
+\code{rendement_8jr}
 }
 \description{
 Koppelt diplomagegevens aan het instroomcohort en berekent of een student

--- a/man/bereken_uitval.Rd
+++ b/man/bereken_uitval.Rd
@@ -4,7 +4,13 @@
 \alias{bereken_uitval}
 \title{Bereken uitvalindicatoren per cohort}
 \usage{
-bereken_uitval(basisbestand, diploma_behaald, cohorten_instroom, jaar)
+bereken_uitval(
+  basisbestand,
+  diploma_behaald,
+  cohorten_instroom,
+  jaar,
+  niveau = "student"
+)
 }
 \arguments{
 \item{basisbestand}{Tibble zoals gemaakt door \code{\link[=maak_basisbestand]{maak_basisbestand()}}}
@@ -15,18 +21,22 @@ bereken_uitval(basisbestand, diploma_behaald, cohorten_instroom, jaar)
 
 \item{jaar}{Integer, peiljaar van de analyse (bijv. \code{2025}). Studenten die
 in \code{jaar - 1} nog ingeschreven staan, gelden als zittend.}
+
+\item{niveau}{Analyseniveau: \code{"student"} (standaard) of \code{"inschrijving"}.
+Moet overeenkomen met het niveau waarop de andere invoertibbles zijn
+aangemaakt.}
 }
 \value{
-Een tibble met kolommen \code{persoonsgebonden_nummer},
-\code{laatste_jaar_inschrijving}, \code{diploma}, \code{status} (factor:
-Diploma behaald / Zittend / Uitgevallen), \code{uitval_xjr} (jaar van uitval
-t.o.v. instroomjaar), \code{uitval_1jr} en \code{uitval_3jr} (factoren).
-Gooit een fout bij dubbele studenten of ontbrekende statussen.
+Een tibble met de sleutelkolom(men), \code{laatste_jaar_inschrijving},
+\code{diploma}, \code{status} (factor: Diploma behaald / Zittend / Uitgevallen),
+\code{uitval_xjr} (jaar van uitval t.o.v. instroomjaar), \code{uitval_1jr} en
+\code{uitval_3jr} (factoren). Gooit een fout bij dubbele sleutelcombinaties of
+ontbrekende statussen.
 }
 \description{
-Bepaalt voor elke student in het instroomcohort of zij zijn uitgevallen,
-zittend of gediplomeerd. Uitval wordt gemarkeerd als een student niet meer
-ingeschreven staat en geen diploma heeft.
+Bepaalt voor elke student (of inschrijving) in het instroomcohort of zij zijn
+uitgevallen, zittend of gediplomeerd. Uitval wordt gemarkeerd als een student
+niet meer ingeschreven staat en geen diploma heeft.
 }
 \examples{
 basis <- tibble::tibble(

--- a/man/combineer_indicatoren.Rd
+++ b/man/combineer_indicatoren.Rd
@@ -8,7 +8,8 @@ combineer_indicatoren(
   cohorten_instroom,
   rendement_indicatoren,
   uitval_indicatoren,
-  studiewissel_indicatoren
+  studiewissel_indicatoren = NULL,
+  niveau = "student"
 )
 }
 \arguments{
@@ -19,16 +20,23 @@ combineer_indicatoren(
 \item{uitval_indicatoren}{Tibble zoals gemaakt door \code{\link[=bereken_uitval]{bereken_uitval()}}}
 
 \item{studiewissel_indicatoren}{Tibble zoals gemaakt door
-\code{\link[=bereken_studiewissel]{bereken_studiewissel()}}}
+\code{\link[=bereken_studiewissel]{bereken_studiewissel()}}, of \code{NULL}. Studiewissel is een
+studentniveau-concept en alleen van toepassing bij
+\code{niveau = "student"}. Geef \code{NULL} door bij inschrijvingsniveau.}
+
+\item{niveau}{Analyseniveau: \code{"student"} (standaard) of \code{"inschrijving"}.
+Moet overeenkomen met het niveau waarop de andere invoertibbles zijn
+aangemaakt.}
 }
 \value{
-Een tibble met een rij per student en gecombineerde indicator-
-kolommen, klaar voor rapportage. Bevat o.a. \code{status}, \code{rendement},
-\code{uitval}, \code{studiewissel} en alle onderliggende deelscores.
+Een tibble met gecombineerde indicatorkolommen, klaar voor
+rapportage. Bevat o.a. \code{status}, \code{rendement}, \code{uitval} en alle
+onderliggende deelscores. Bij \code{niveau = "student"} zijn ook
+studiewisselkolommen aanwezig als \code{studiewissel_indicatoren} is meegegeven.
 }
 \description{
-Voegt rendement-, uitval- en studiewisselindicatoren samen met het
-instroomcohort. Past kolomnamen en factorniveaus aan voor gebruik in
+Voegt rendement-, uitval- en (optioneel) studiewisselindicatoren samen met
+het instroomcohort. Past kolomnamen en factorniveaus aan voor gebruik in
 rapportages.
 }
 \examples{

--- a/man/maak_basisbestand.Rd
+++ b/man/maak_basisbestand.Rd
@@ -14,10 +14,13 @@ Een tibble met alle 1CHO-regels plus extra \verb{_label}-kolommen die de
 originele categorische waarden bewaren voor gebruik in rapportages
 }
 \description{
-Lees het 1CHO-bestand in en voeg label-kolommen toe
+Leest een semicolongescheiden CSV-bestand (UTF-8) in en voegt
+extra \verb{_label}-kolommen toe voor gebruik in rapportages. Het pakket
+bevat een klein synthetisch voorbeeldbestand zonder echte persoonsgegevens
+(\code{inst/extdata/voorbeeld_1cho.csv}).
 }
 \examples{
-\dontrun{
-  basis <- maak_basisbestand("pad/naar/1cho_enriched.csv")
-}
+# voorbeeld_1cho.csv is a small synthetic dataset bundled with the package
+pad <- system.file("extdata/voorbeeld_1cho.csv", package = "staat1cho")
+basis <- suppressMessages(maak_basisbestand(pad))
 }

--- a/man/maak_diploma_behaald.Rd
+++ b/man/maak_diploma_behaald.Rd
@@ -2,22 +2,25 @@
 % Please edit documentation in R/rendement.R
 \name{maak_diploma_behaald}
 \alias{maak_diploma_behaald}
-\title{Maak een bestand met het vroegst behaalde diploma per student}
+\title{Maak een bestand met het vroegst behaalde diploma per student (of inschrijving)}
 \usage{
-maak_diploma_behaald(basisbestand)
+maak_diploma_behaald(basisbestand, niveau = "student")
 }
 \arguments{
 \item{basisbestand}{Tibble zoals gemaakt door \code{\link[=maak_basisbestand]{maak_basisbestand()}}}
+
+\item{niveau}{Analyseniveau: \code{"student"} (standaard) of \code{"inschrijving"}.
+Bepaalt de sleutel waarop gededupliceerd wordt.}
 }
 \value{
-Een tibble met één rij per student met kolommen
-\code{persoonsgebonden_nummer}, \code{jaar_eerste_diploma},
-\code{verblijfsjaar_eerste_diploma} en \code{diploma}. Gooit een fout bij
-dubbele persoonsgebonden nummers.
+Een tibble met één rij per student (bij \code{niveau = "student"}) of per
+student-opleidingcombinatie (bij \code{niveau = "inschrijving"}), met kolommen
+voor de sleutel(s), \code{jaar_eerste_diploma}, \code{verblijfsjaar_eerste_diploma}
+en \code{diploma}. Gooit een fout bij dubbele sleutelcombinaties.
 }
 \description{
 Filtert het basisbestand op diplomasoorten die gelden als afgeronde opleiding
-en behoudt per student alleen het eerste diploma op basis van diplomajaar.
+en behoudt per sleutel alleen het eerste diploma op basis van diplomajaar.
 }
 \examples{
 basis <- tibble::tibble(

--- a/man/maak_instroom_cohort.Rd
+++ b/man/maak_instroom_cohort.Rd
@@ -4,18 +4,24 @@
 \alias{maak_instroom_cohort}
 \title{Maak een eerstejaarscohort per instelling}
 \usage{
-maak_instroom_cohort(basisbestand, soort_ho)
+maak_instroom_cohort(basisbestand, soort_ho, niveau = "student")
 }
 \arguments{
 \item{basisbestand}{Tibble zoals gemaakt door \code{\link[=maak_basisbestand]{maak_basisbestand()}}}
 
 \item{soort_ho}{Character vector met toegestane waarden van
 \code{soort_hoger_onderwijs}, bijv. \code{c("hoger beroepsonderwijs", "hbo")}}
+
+\item{niveau}{Analyseniveau: \code{"student"} (standaard) of \code{"inschrijving"}.
+Bij \code{"student"} is de sleutel \code{persoonsgebonden_nummer}; bij
+\code{"inschrijving"} is de sleutel de combinatie
+\code{persoonsgebonden_nummer} + \code{opleiding_actueel_equivalent}.}
 }
 \value{
-Een tibble met één rij per student, aangevuld met kolom
-\code{eerstejaar_instelling} (= inschrijvingsjaar). Gooit een fout als er
-dubbele persoonsgebonden nummers zijn.
+Een tibble met een rij per student (bij \code{niveau = "student"}) of per
+student-opleidingcombinatie (bij \code{niveau = "inschrijving"}), aangevuld met
+kolom \code{eerstejaar_instelling} (= inschrijvingsjaar). Gooit een fout als er
+dubbele sleutelcombinaties zijn.
 }
 \description{
 Filtert het basisbestand op het opgegeven soort hoger onderwijs,

--- a/man/start_dashboard.Rd
+++ b/man/start_dashboard.Rd
@@ -6,12 +6,15 @@
 \usage{
 start_dashboard()
 }
+\value{
+No return value, called for side effects.
+}
 \description{
 Opent de interactieve Shiny app waarmee je een 1CHO CSV-bestand kunt
 uploaden en studie-indicatoren kunt verkennen.
 }
 \examples{
-\dontrun{
+if (interactive()) {
   start_dashboard()
 }
 }


### PR DESCRIPTION
## Wat

Alle pipeline-functies accepteren nu een `niveau`-parameter (`"student"` of `"inschrijving"`). Bij inschrijvingsniveau is de sleutel `persoonsgebonden_nummer + opleiding_actueel_equivalent`, zodat een student met meerdere inschrijvingen op programmaniveau geanalyseerd kan worden.

## Wijzigingen

- Nieuwe interne helper `niveau_sleutels()` in `R/utils.R` die de join-sleutel(s) bepaalt op basis van het niveau
- `maak_instroom_cohort`, `maak_diploma_behaald`, `bereken_rendement`, `bereken_uitval` en `combineer_indicatoren` hebben elk een `niveau`-parameter gekregen
- `combineer_indicatoren` accepteert `studiewissel_indicatoren = NULL` (studiewissel is bewust buiten scope voor inschrijvingsniveau)
- Dashboard: niveaukeuze op het uploadscherm, badge in de header die het actieve niveau toont, y-as en tellerteksten passen zich aan

## Testplan

- Getest met het meegeleverde voorbeeldbestand op beide niveaus
- 105 unit tests slagen
- R CMD check: 0 errors, 0 warnings

Closes #2